### PR TITLE
Fixing bindgen issue: version 'sim' in target triple 'aarch64-apple-i…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,10 @@ tracing-core = "0.1"
 tracing-subscriber = "0.3"
 
 [build-dependencies]
-bindgen = "0.64"
+# Using this version where this issue has already being fixed: https://github.com/rust-lang/rust-bindgen/issues/3181
+# version 'sim' in target triple 'aarch64-apple-ios-sim' is invalid
+# TODO: return to use a specific version once a new release with the fix is available
+bindgen = { git = "https://github.com/rust-lang/rust-bindgen", rev = "97ab9152b5edb1fda1ced9bc1604f5e4dc9cfaa9" }
 cc = "1.0"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Using version from specific commit to fix the issue:
version 'sim' in target triple 'aarch64-apple-ios-sim' is invalid

https://github.com/rust-lang/rust-bindgen/issues/3181